### PR TITLE
Add alternative tty dev path for Ender2

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,6 +23,7 @@ services:
       - 80:80
     devices:
       - /dev/ttyACM0:/dev/ttyACM0
+      - /dev/ttyUSB0:/dev/ttyUSB0
     volumes:
       - ./data/octoprint:/octoprint
       - /proc/cpuinfo:/proc/cpuinfo:ro

--- a/mjpg-streamer/Dockerfile
+++ b/mjpg-streamer/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y cmake build-essential curl git
 RUN echo "deb http://archive.raspberrypi.org/debian/ bullseye main" > /etc/apt/sources.list.d/raspi.list
 RUN curl "https://archive.raspberrypi.org/debian/raspberrypi.gpg.key" | apt-key add -
 
-RUN apt-get update && apt-get install -y libcamera-dev libjpeg-dev libgphoto2-dev
+RUN apt-get update && apt-get install -y libcamera-dev libjpeg-dev libgphoto2-dev ffmpeg
 
 RUN git clone https://github.com/ArduCAM/mjpg-streamer.git /src
 WORKDIR /src/mjpg-streamer-experimental


### PR DESCRIPTION
# What does this PR do?
My Ender2 on the latest 64-bit Raspbian shows up as /dev/ttyUSB0 so I added it as an extra mount for greater support